### PR TITLE
Gh 43 statement implementation

### DIFF
--- a/src/org/hpccsystems/jdbcdriver/HPCCConnection.java
+++ b/src/org/hpccsystems/jdbcdriver/HPCCConnection.java
@@ -99,7 +99,8 @@ public class HPCCConnection implements Connection
 
     public Statement createStatement() throws SQLException
     {
-        return new HPCCPreparedStatement(this, null);
+        System.out.println("HPCCConnection: createStatement(  )");
+        return new HPCCStatement(this);
     }
 
     public PreparedStatement prepareStatement(String query) throws SQLException

--- a/src/org/hpccsystems/jdbcdriver/HPCCPreparedStatement.java
+++ b/src/org/hpccsystems/jdbcdriver/HPCCPreparedStatement.java
@@ -35,629 +35,373 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
-import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.HashMap;
 
-import org.w3c.dom.NodeList;
-
 /**
  *
  * @author rpastrana
  */
 
-public class HPCCPreparedStatement implements PreparedStatement
+public class HPCCPreparedStatement extends HPCCStatement implements PreparedStatement
 {
-    private boolean                  closed        = false;
-    private int                      maxRows       = 100;
-    private String                   sqlQuery;
-    private HPCCConnection           hpccConnection;
     private HashMap<Integer, Object> parameters    = new HashMap<Integer, Object>();
-    private SQLWarning               warnings;
-    private HPCCResultSet            result        = null;
-    private HPCCResultSetMetadata    resultMetadata = null;
-
-    private HPCCDatabaseMetaData                dbMetadata;
-    private ECLEngine                           eclQuery = null;
-    private SQLParser                           parser = new SQLParser();
+    protected static final String      className = "HPCCPreparedStatement";
 
     public HPCCPreparedStatement(Connection connection, String query)
     {
-        HPCCJDBCUtils.traceoutln("HPCCPreparedStatement Constructor: Sqlquery: " + query);
+        super(connection);
+
+        System.out.println(className + " Constructor: Sqlquery: " + query);
         this.sqlQuery = query;
-        this.hpccConnection = (HPCCConnection)connection;
-        this.dbMetadata = hpccConnection.getDatabaseMetaData();
 
         if (sqlQuery != null)
             processQuery();
     }
 
-    private void processQuery()
-    {
-        try
-        {
-            HPCCJDBCUtils.traceoutln("Attempting to process sql query: " + sqlQuery);
-            if (!this.closed)
-            {
-                if (parser != null)
-                    parser.process(sqlQuery);
-                else
-                    throw new SQLException("Error parser is not ready, cannot execute query");
-
-                eclQuery = new ECLEngine(parser, dbMetadata, hpccConnection.getProperties());
-
-                eclQuery.generateECL();
-                resultMetadata = new HPCCResultSetMetadata(eclQuery.getExpectedRetCols(), "HPCC Result");
-            }
-            else
-                throw new SQLException("HPCCPreparedStatement closed, cannot execute query");
-        }
-        catch (SQLException e)
-        {
-            System.out.println(e.getLocalizedMessage());
-            if (warnings == null)
-                warnings = new SQLWarning();
-            warnings.setNextException(e);
-
-            eclQuery = null;
-            parser = null;
-        }
-    }
-
     public ResultSet executeQuery() throws SQLException
     {
-        HPCCJDBCUtils.traceoutln("HPCCPreparedStatement:executeQuery()");
-        HPCCJDBCUtils.traceoutln("Attempting to process sql query: " + sqlQuery);
-        result = null;
-
-        try
-        {
-            if (!this.closed)
-            {
-                if (eclQuery == null)
-                {
-                    String message = "HPCCPreparedStatement: Cannot execute SQL command";
-
-                    if (warnings != null)
-                    {
-                        SQLException  we = warnings.getNextException();
-                        if(we != null)
-                            message += "\n\t" + we.getLocalizedMessage();
-                    }
-                    throw new SQLException(message);
-                }
-
-                NodeList rowList = eclQuery.execute(parameters);
-
-                if (rowList != null)
-                    result = new HPCCResultSet(this, rowList, resultMetadata);
-            }
-            else
-                throw new SQLException("HPCCPreparedStatement closed, cannot execute query");
-        }
-        catch (Exception e)
-        {
-            SQLException sqlexcept = new SQLException(e.getLocalizedMessage());
-            sqlexcept.setStackTrace(e.getStackTrace());
-
-            if (warnings == null)
-                warnings = new SQLWarning();
-
-            warnings.setNextException(sqlexcept);
-
-            throw sqlexcept;
-        }
+        System.out.println(className + ":executeQuery()");
+        executeHPCCQuery(parameters);
 
         return result;
     }
 
     public int executeUpdate() throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT: executeUpdate Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ":  executeUpdate Not supported yet.");
+        throw new UnsupportedOperationException(className + ":  executeUpdate Not supported yet.");
     }
 
     public void setNull(int parameterIndex, int sqlType) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setNull(" + parameterIndex + ", " + sqlType + " )");
         parameters.put(new Integer(parameterIndex), sqlType);
     }
 
     public void setBoolean(int parameterIndex, boolean x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setBoolean(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setByte(int parameterIndex, byte x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setByte(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setShort(int parameterIndex, short x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setShort(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setInt(int parameterIndex, int x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setInt(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setLong(int parameterIndex, long x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setLong(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setFloat(int parameterIndex, float x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setFloat(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setDouble(int parameterIndex, double x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setString(int parameterIndex, String x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setBytes(int parameterIndex, byte[] x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setDate(int parameterIndex, Date x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setTime(int parameterIndex, Time x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT: setAsciiStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ":  setAsciiStream Not supported yet.");
     }
 
     public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT: setUnicodeStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ":  setUnicodeStream Not supported yet.");
     }
 
     public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT: setBinaryStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ":  setBinaryStream Not supported yet.");
     }
 
     public void clearParameters() throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": clearParameters()");
         parameters.clear();
     }
 
     public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setObject(int parameterIndex, Object x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public boolean execute() throws SQLException
     {
-        HPCCJDBCUtils.traceoutln("HPCCPreparedStatement:execute()");
-        HPCCJDBCUtils.traceoutln("Attempting to process sql query: " + sqlQuery);
+        System.out.println(className + ": execute()");
+        System.out.println(  "Attempting to process sql query: " + sqlQuery);
         return executeQuery() != null;
     }
 
     public void addBatch() throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT: addBatch Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": addBatch()");
+        throw new UnsupportedOperationException(className + ":  addBatch Not supported yet.");
     }
 
     public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setCharacterStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setCharacterStream(" + parameterIndex + ", " + reader + " )");
+        throw new UnsupportedOperationException(className + ": setCharacterStream Not supported yet.");
     }
 
     public void setRef(int parameterIndex, Ref x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setRef(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setBlob(int parameterIndex, Blob x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setBlob(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setClob(int parameterIndex, Clob x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setClob(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setArray(int parameterIndex, Array x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public ResultSetMetaData getMetaData() throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": getMetaData()");
         return result != null ? result.getMetaData() : null;
     }
 
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setDate Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setDate(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ": setDate Not supported yet.");
     }
 
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setTime Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setTime(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ": setTime Not supported yet.");
     }
 
     public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setTimestamp Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setTimestamp(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ": setTimestamp Not supported yet.");
     }
 
     public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setNull Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setNull(" + parameterIndex + ", " + sqlType + " )");
+        throw new UnsupportedOperationException(className + ": setNull Not supported yet.");
     }
 
     public void setURL(int parameterIndex, URL x) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setURL(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public ParameterMetaData getParameterMetaData() throws SQLException
     {
-        HPCCJDBCUtils.traceoutln("HPCCPREPSTATEMENT getParameterMetaData");
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:getParameterMetaData Not supported yet.");
+        HPCCJDBCUtils.traceoutln(  "HPCCPREPSTATEMENT getParameterMetaData");
+        throw new UnsupportedOperationException(className + ": getParameterMetaData Not supported yet.");
     }
 
     public void setRowId(int parameterIndex, RowId x) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setRowId Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setRowId(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ": setRowId Not supported yet.");
     }
 
     public void setNString(int parameterIndex, String value) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setNString(" + parameterIndex + ", " + value + " )");
         parameters.put(new Integer(parameterIndex), value);
     }
 
     public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setNCharacterStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setNCharacterStream(" + parameterIndex + ", " + value + " )");
+        throw new UnsupportedOperationException(className + ": setNCharacterStream Not supported yet.");
     }
 
     public void setNClob(int parameterIndex, NClob value) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setNClob(" + parameterIndex + ", " + value + " )");
         parameters.put(new Integer(parameterIndex), value);
     }
 
     public void setClob(int parameterIndex, Reader reader, long length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setClob Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setClob(" + parameterIndex + ", " + reader + " )");
+        throw new UnsupportedOperationException(className + ": setClob Not supported yet.");
     }
 
     public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setBlob Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setBlob(" + parameterIndex + ", " + inputStream + " )");
+        throw new UnsupportedOperationException(className + ": setBlob Not supported yet.");
     }
 
     public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setNClob Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setNClob(" + parameterIndex + ", " + reader + " )");
+        throw new UnsupportedOperationException(className + ": setNClob Not supported yet.");
     }
 
     public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setSQLXML(" + parameterIndex + ", " + xmlObject + " )");
         parameters.put(new Integer(parameterIndex), xmlObject);
     }
 
     public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + x + " )");
         parameters.put(new Integer(parameterIndex), x);
     }
 
     public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setAsciiStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setAsciiStream(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ": setAsciiStream Not supported yet.");
     }
 
     public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setBinaryStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setBinaryStream(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ": setBinaryStream Not supported yet.");
     }
 
     public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setCharacterStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setDouble(" + parameterIndex + ", " + reader + " )");
+        throw new UnsupportedOperationException(className + ": setCharacterStream Not supported yet.");
     }
 
     public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setAsciiStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setAsciiStream(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ": setAsciiStream Not supported yet.");
     }
 
     public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setBinaryStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setBinaryStream(" + parameterIndex + ", " + x + " )");
+        throw new UnsupportedOperationException(className + ": setBinaryStream Not supported yet.");
     }
 
     public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setCharacterStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setCharacterStream(" + parameterIndex + ", " + reader + " )");
+        throw new UnsupportedOperationException(className + ": setCharacterStream Not supported yet.");
     }
 
     public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setNCharacterStream Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setNCharacterStream(" + parameterIndex + ", " + value + " )");
+        throw new UnsupportedOperationException(className + ": setNCharacterStream Not supported yet.");
     }
 
     public void setClob(int parameterIndex, Reader reader) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setClob Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setClob(" + parameterIndex + ", " + reader + " )");
+        throw new UnsupportedOperationException(className + ": setClob Not supported yet.");
     }
 
     public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setBlob Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setBlob(" + parameterIndex + ", " + inputStream + " )");
+        throw new UnsupportedOperationException(className + ": setBlob Not supported yet.");
     }
 
     public void setNClob(int parameterIndex, Reader reader) throws SQLException
     {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setNClob Not supported yet.");
-    }
-
-    public ResultSet executeQuery(String query) throws SQLException
-    {
-        sqlQuery = query;
-
-        HPCCJDBCUtils.traceoutln("ECLPreparedStatement: executeQuery(" + query + ")");
-
-        processQuery();
-
-        return executeQuery();
-    }
-
-    public int executeUpdate(String sql) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:executeUpdate Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setNClob(" + parameterIndex + ", " + reader + " )");
+        throw new UnsupportedOperationException(className + ": setNClob Not supported yet.");
     }
 
     public void close() throws SQLException
     {
+        HPCCJDBCUtils.traceoutln(className + ": close()");
         if (!closed)
         {
-            closed = true;
-            hpccConnection = null;
-            result = null;
-            sqlQuery = null;
-            dbMetadata = null;
+            super.close();
             parameters = null;
-            parser = null;
-            eclQuery = null;
         }
-    }
-
-    public int getMaxFieldSize() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT: getMaxFieldSizeNot supported yet.");
-    }
-
-    public void setMaxFieldSize(int max) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setMaxFieldSize Not supported yet.");
-    }
-
-    public int getMaxRows() throws SQLException
-    {
-        return maxRows;
-    }
-
-    public void setMaxRows(int max) throws SQLException
-    {
-        maxRows = max;
-    }
-
-    public void setEscapeProcessing(boolean enable) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setEscapeProcessing Not supported yet.");
-    }
-
-    public int getQueryTimeout() throws SQLException
-    {
-        return -1;
-    }
-
-    public void setQueryTimeout(int seconds) throws SQLException
-    {
-        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setQueryTimeout Not supported yet.");
-    }
-
-    public void cancel() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:cancel Not supported yet.");
-    }
-
-    public SQLWarning getWarnings() throws SQLException
-    {
-        return warnings;
-    }
-
-    public void clearWarnings() throws SQLException
-    {
-        warnings = null;
-    }
-
-    public void setCursorName(String name) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setCursorName Not supported yet.");
-    }
-
-    public boolean execute(String sql) throws SQLException
-    {
-        HPCCJDBCUtils.traceoutln("HPCCPreparedStatement:execute(" + sql + ")");
-        sqlQuery = sql;
-
-        processQuery();
-
-        return execute();
-    }
-
-    public ResultSet getResultSet() throws SQLException
-    {
-        return result;
-    }
-
-    public int getUpdateCount() throws SQLException
-    {
-        return 0;
-    }
-
-    public boolean getMoreResults() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:getMoreResults Not supported yet.");
-    }
-
-    public void setFetchDirection(int direction) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setFetchDirection Not supported yet.");
-    }
-
-    public int getFetchDirection() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:getFetchDirection Not supported yet.");
-    }
-
-    public void setFetchSize(int rows) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setFetchSize Not supported yet.");
-    }
-
-    public int getFetchSize() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:getFetchSize Not supported yet.");
-    }
-
-    public int getResultSetConcurrency() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:getResultSetConcurrency Not supported yet.");
-    }
-
-    public int getResultSetType() throws SQLException
-    {
-        return ResultSet.TYPE_FORWARD_ONLY;
-    }
-
-    public void addBatch(String sql) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:addBatch Not supported yet.");
-    }
-
-    public void clearBatch() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:clearBatch Not supported yet.");
-    }
-
-    public int[] executeBatch() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:executeBatch Not supported yet.");
-    }
-
-    public Connection getConnection() throws SQLException
-    {
-        return hpccConnection;
-    }
-
-    public boolean getMoreResults(int current) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:getMoreResults Not supported yet.");
-    }
-
-    public ResultSet getGeneratedKeys() throws SQLException
-    {
-        return null;
-    }
-
-    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:executeUpdate Not supported yet.");
-    }
-
-    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:executeUpdate Not supported yet.");
-    }
-
-    public int executeUpdate(String sql, String[] columnNames) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:executeUpdate Not supported yet.");
-    }
-
-    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException
-    {
-        throw new UnsupportedOperationException(
-                "HPCCPREPSTATEMNT:execute(String sql, int autoGeneratedKeys) Not supported yet.");
-    }
-
-    public boolean execute(String sql, int[] columnIndexes) throws SQLException
-    {
-        throw new UnsupportedOperationException(
-                "HPCCPREPSTATEMNT:execute(String sql, int[] columnIndexes) Not supported yet.");
-    }
-
-    public boolean execute(String sql, String[] columnNames) throws SQLException
-    {
-        throw new UnsupportedOperationException(
-                "HPCCPREPSTATEMNT:execute(String sql, String[] columnNames) Not supported yet.");
-    }
-
-    public int getResultSetHoldability() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:getResultSetHoldability Not supported yet.");
-    }
-
-    public boolean isClosed() throws SQLException
-    {
-        return closed;
-    }
-
-    public void setPoolable(boolean poolable) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:setPoolable Not supported yet.");
-    }
-
-    public boolean isPoolable() throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:isPoolable Not supported yet.");
-    }
-
-    public <T> T unwrap(Class<T> iface) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:unwrap Not supported yet.");
-    }
-
-    public boolean isWrapperFor(Class<?> iface) throws SQLException
-    {
-        throw new UnsupportedOperationException("HPCCPREPSTATEMNT:isWrapperFor Not supported yet.");
     }
 }

--- a/src/org/hpccsystems/jdbcdriver/HPCCStatement.java
+++ b/src/org/hpccsystems/jdbcdriver/HPCCStatement.java
@@ -23,6 +23,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.util.HashMap;
+
+import org.w3c.dom.NodeList;
 
 /**
  *
@@ -31,100 +34,252 @@ import java.sql.Statement;
 
 public class HPCCStatement implements Statement
 {
+    protected boolean                  closed        = false;
+    protected String                   sqlQuery;
+    protected HPCCConnection           hpccConnection;
+    protected SQLWarning               warnings;
+    protected HPCCResultSet            result        = null;
+    protected HPCCResultSetMetadata    resultMetadata = null;
+
+    protected HPCCDatabaseMetaData     dbMetadata;
+    protected ECLEngine                eclQuery = null;
+    protected SQLParser                parser = new SQLParser();
+    protected static final String      className = "HPCCStatement";
+    public static final String         hpccResultSetName = "HPCC Result";
+
+    public HPCCStatement(Connection conn)
+    {
+		System.out.println(className + "Constructor(conn)");
+        this.hpccConnection = (HPCCConnection)conn;
+        this.dbMetadata = hpccConnection.getDatabaseMetaData();
+    }
+
+    protected void processQuery()
+    {
+        try
+        {
+            System.out.println(className + "Attempting to process sql query: " + sqlQuery);
+            if (!this.closed)
+            {
+                if (parser != null)
+                    parser.process(sqlQuery);
+                else
+                    throw new SQLException("Error parser is not ready, cannot execute query");
+
+                eclQuery = new ECLEngine(parser, dbMetadata, hpccConnection.getProperties());
+
+                eclQuery.generateECL();
+                resultMetadata = new HPCCResultSetMetadata(eclQuery.getExpectedRetCols(), hpccResultSetName);
+            }
+            else
+                throw new SQLException("HPCCPreparedStatement closed, cannot execute query");
+        }
+        catch (SQLException e)
+        {
+            System.out.println(  e.getLocalizedMessage());
+            if (warnings == null)
+                warnings = new SQLWarning();
+            warnings.setNextException(e);
+
+            eclQuery = null;
+            parser = null;
+        }
+    }
+
+    protected ResultSet executeHPCCQuery(HashMap<Integer, Object> params) throws SQLException
+    {
+		System.out.println(className + ": executeQuery()");
+		System.out.println("\tAttempting to process sql query: " + sqlQuery);
+        result = null;
+
+        try
+        {
+            if (!this.closed)
+            {
+                if (eclQuery == null)
+                {
+                    String message = className + ":  Cannot execute SQL command";
+
+                    if (warnings != null)
+                    {
+                        SQLException  we = warnings.getNextException();
+                        if(we != null)
+                            message += "\n\t" + we.getLocalizedMessage();
+                    }
+                    throw new SQLException(message);
+                }
+
+                NodeList rowList = eclQuery.execute(params);
+
+                if (rowList != null)
+                    result = new HPCCResultSet(this, rowList, resultMetadata);
+            }
+            else
+                throw new SQLException(className + "is closed, cannot execute query");
+        }
+        catch (Exception e)
+        {
+            throw convertToSQLExceptionAndAddWarn(e);
+        }
+
+        return result;
+    }
+
+    private SQLException convertToSQLExceptionAndAddWarn(Exception e)
+    {
+        SQLException sqlexcept = new SQLException(e.getLocalizedMessage());
+        sqlexcept.setStackTrace(e.getStackTrace());
+
+        if (warnings == null)
+            warnings = new SQLWarning();
+
+        warnings.setNextException(sqlexcept);
+
+        return sqlexcept;
+    }
 
     public ResultSet executeQuery(String sql) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: executeQuery(String sql) Not supported yet.");
+        sqlQuery = sql;
+
+		System.out.println(className + ": executeQuery(" + sql + ")");
+
+        processQuery();
+
+        return executeHPCCQuery(null);
     }
 
     public int executeUpdate(String sql) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: executeUpdate(String sql) Not supported yet.");
+        throw new UnsupportedOperationException(className + ": executeUpdate(String sql) Not supported yet.");
     }
 
     public void close() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: close() Not supported yet.");
+		HPCCJDBCUtils.traceoutln(className + ": close( )");
+        if (!closed)
+        {
+            closed = true;
+            hpccConnection = null;
+            result = null;
+            sqlQuery = null;
+            dbMetadata = null;
+            parser = null;
+            eclQuery = null;
+        }
     }
 
     public int getMaxFieldSize() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getMaxFieldSize() Not supported yet.");
+        throw new UnsupportedOperationException(className + ": getMaxFieldSize() Not supported yet.");
     }
 
     public void setMaxFieldSize(int max) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: setMaxFieldSize(int max) Not supported yet.");
+        throw new UnsupportedOperationException(className + ": setMaxFieldSize(int max) Not supported yet.");
     }
 
     public int getMaxRows() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getMaxRows() Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": getMaxRows(  )");
+        try
+        {
+            return Integer.parseInt(this.hpccConnection.getProperty("EclLimit"));
+        }
+        catch (Exception e)
+        {
+            throw new SQLException("Could not determine MaxRows");
+        }
     }
 
     public void setMaxRows(int max) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: setMaxRows(int max) Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setMaxRows(" + max + "  ) ignored");
     }
 
     public void setEscapeProcessing(boolean enable) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: setEscapeProcessing(boolean enable) Not supported yet.");
+        throw new UnsupportedOperationException(className + ": setEscapeProcessing(boolean enable) Not supported yet.");
     }
 
     public int getQueryTimeout() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement:  getQueryTimeout() Not supported yet.");
+		HPCCJDBCUtils.traceoutln(className + ": getQueryTimeout()");
+        return 0;
     }
 
     public void setQueryTimeout(int seconds) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: setQueryTimeout(int seconds) Not supported yet.");
+		HPCCJDBCUtils.traceoutln(className + ": setQueryTimeout()");
     }
 
     public void cancel() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: cancel()  Not supported yet.");
+        throw new UnsupportedOperationException(className + ": cancel()  Not supported yet.");
     }
 
     public SQLWarning getWarnings() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getWarnings Not supported yet.");
+		HPCCJDBCUtils.traceoutln(className + ": getWarnings()");
+        return warnings;
     }
 
     public void clearWarnings() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: clearWarnings() Not supported yet.");
+		HPCCJDBCUtils.traceoutln(className + ": clearWarnings()");
+        warnings = null;
     }
 
     public void setCursorName(String name) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement:  setCursorName(String name) Not supported yet.");
+        throw new UnsupportedOperationException(className + ":  setCursorName(String name) Not supported yet.");
     }
 
     public boolean execute(String sql) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: execute(String sql) Not supported yet.");
+        sqlQuery = sql;
+
+        processQuery();
+
+        return execute();
+    }
+
+    public boolean execute() throws SQLException
+    {
+        result = null;
+		System.out.println(className + ": execute()");
+		System.out.println(  "\tAttempting to process sql query: " + sqlQuery);
+        try
+        {
+            result = (HPCCResultSet) executeHPCCQuery(null);
+        }
+        catch (Exception e)
+        {
+            //Unlikely to occur, but if it does, should report in sqlwarnings
+            throw convertToSQLExceptionAndAddWarn(e);
+        }
+        return result != null;
     }
 
     public ResultSet getResultSet() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getResultSet Not supported yet.");
+        return result;
     }
 
     public int getUpdateCount() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement:getUpdateCount  Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ":getUpdateCount: -1");
+        return -1;
     }
 
     public boolean getMoreResults() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getMoreResults Not supported yet.");
+        throw new UnsupportedOperationException(className + ": getMoreResults Not supported yet.");
     }
 
     public void setFetchDirection(int direction) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: only ResultSet.FETCH_FORWARD supported");
+        throw new UnsupportedOperationException(className + ": only ResultSet.FETCH_FORWARD supported");
     }
 
     public int getFetchDirection() throws SQLException
@@ -134,118 +289,118 @@ public class HPCCStatement implements Statement
 
     public void setFetchSize(int rows) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: setFetchSize(int rows) Not supported yet.");
+        HPCCJDBCUtils.traceoutln(className + ": setFetchSize Not supported yet.");
     }
 
     public int getFetchSize() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getFetchSize() Not supported yet.");
+        return -1;
     }
 
     public int getResultSetConcurrency() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getResultSetConcurrency() Not supported yet.");
+        throw new UnsupportedOperationException(className + ": getResultSetConcurrency() Not supported yet.");
     }
 
     public int getResultSetType() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement:  getResultSetType() Not supported yet.");
+        throw new UnsupportedOperationException(className + ":  getResultSetType() Not supported yet.");
     }
 
     public void addBatch(String sql) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: addBatch(String sql) Not supported yet.");
+        throw new UnsupportedOperationException(className + ": addBatch(String sql) Not supported yet.");
     }
 
     public void clearBatch() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: clearBatch() Not supported yet.");
+        throw new UnsupportedOperationException(className + ": clearBatch() Not supported yet.");
     }
 
     public int[] executeBatch() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: executeBatch() Not supported yet.");
+        throw new UnsupportedOperationException(className + ": executeBatch() Not supported yet.");
     }
 
     public Connection getConnection() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getConnection() Not supported yet.");
+        return hpccConnection;
     }
 
     public boolean getMoreResults(int current) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getMoreResults(int current) Not supported yet.");
+        throw new UnsupportedOperationException(className + ": getMoreResults(int current) Not supported yet.");
     }
 
     public ResultSet getGeneratedKeys() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getGeneratedKeys() Not supported yet.");
+        throw new UnsupportedOperationException(className + ": getGeneratedKeys() Not supported yet.");
     }
 
     public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException
     {
         throw new UnsupportedOperationException(
-                "EclStatement: executeUpdate(String sql, int autoGeneratedKeys) Not supported yet.");
+                className + ": executeUpdate(String sql, int autoGeneratedKeys) Not supported yet.");
     }
 
     public int executeUpdate(String sql, int[] columnIndexes) throws SQLException
     {
         throw new UnsupportedOperationException(
-                "EclStatement:  executeUpdate(String sql, int[] columnIndexes) Not supported yet.");
+                className + ":  executeUpdate(String sql, int[] columnIndexes) Not supported yet.");
     }
 
     public int executeUpdate(String sql, String[] columnNames) throws SQLException
     {
         throw new UnsupportedOperationException(
-                "EclStatement: executeUpdate(String sql, String[] columnNames) Not supported yet.");
+                className + ": executeUpdate(String sql, String[] columnNames) Not supported yet.");
     }
 
     public boolean execute(String sql, int autoGeneratedKeys) throws SQLException
     {
         throw new UnsupportedOperationException(
-                "EclStatement: execute(String sql, int autoGeneratedKeys) Not supported yet.");
+                className + ": execute(String sql, int autoGeneratedKeys) Not supported yet.");
     }
 
     public boolean execute(String sql, int[] columnIndexes) throws SQLException
     {
         throw new UnsupportedOperationException(
-                "EclStatement:  execute(String sql, int[] columnIndexes) Not supported yet.");
+                className + ":  execute(String sql, int[] columnIndexes) Not supported yet.");
     }
 
     public boolean execute(String sql, String[] columnNames) throws SQLException
     {
         throw new UnsupportedOperationException(
-                "EclStatement: execute(String sql, String[] columnNames) Not supported yet.");
+                className + ": execute(String sql, String[] columnNames) Not supported yet.");
     }
 
     public int getResultSetHoldability() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: getResultSetHoldability Not supported yet.");
+        throw new UnsupportedOperationException(className + ": getResultSetHoldability Not supported yet.");
     }
 
     public boolean isClosed() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: isClosed() Not supported yet.");
+        throw new UnsupportedOperationException(className + ": isClosed() Not supported yet.");
     }
 
     public void setPoolable(boolean poolable) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: Not supported yet.");
+        throw new UnsupportedOperationException(className + ": Not supported yet.");
     }
 
     public boolean isPoolable() throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: Not supported yet.");
+        throw new UnsupportedOperationException(className + ": Not supported yet.");
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: Not supported yet.");
+        throw new UnsupportedOperationException(className + ": Not supported yet.");
     }
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException
     {
-        throw new UnsupportedOperationException("EclStatement: Not supported yet.");
+        throw new UnsupportedOperationException(className + ": Not supported yet.");
     }
 
 }

--- a/src/org/hpccsystems/jdbcdriver/SQLParser.java
+++ b/src/org/hpccsystems/jdbcdriver/SQLParser.java
@@ -82,6 +82,15 @@ public class SQLParser
         storedProcName = null;
         sqlType = SQLType.UNKNOWN;
         indexHint = null;
+        columnsVerified = false;
+        joinClause = null;
+        groupByFragments = null;
+        orderByFragments = null;
+        procInParamValues = null;
+        limit = -1;
+        selectColsContainWildcard = false;
+        isSelectDistinct = false;
+        parameterizedCount = 0;
 
         insql = HPCCJDBCUtils.removeAllNewLines(insql);
         String insqlupcase = insql.toUpperCase();

--- a/src/org/hpccsystems/jdbcdriver/tests/HPCCDriverTest.java
+++ b/src/org/hpccsystems/jdbcdriver/tests/HPCCDriverTest.java
@@ -17,6 +17,7 @@ import org.hpccsystems.jdbcdriver.HPCCDriver;
 import org.hpccsystems.jdbcdriver.HPCCJDBCUtils;
 import org.hpccsystems.jdbcdriver.HPCCPreparedStatement;
 import org.hpccsystems.jdbcdriver.HPCCResultSet;
+import org.hpccsystems.jdbcdriver.HPCCStatement;
 
 public class HPCCDriverTest
 {
@@ -1131,6 +1132,27 @@ public class HPCCDriverTest
                 info.put("EclResultLimit", "ALL"); //I want all records returned
                 info.put("PageSize", "20"); //GetTables and GetProcs will only return 20 entries
 
+
+                HPCCConnection connectionprops = connectViaProps(info);
+                if (connectionprops == null)
+                    throw new RuntimeException("Could not connect with properties object");
+
+                HPCCStatement stmt = (HPCCStatement) connectionprops.createStatement();
+
+                String stmtsql = "select tbl.* from lotto::winning::numbers::date::csv tbl limit 10";
+                if( stmt.execute(stmtsql))
+                {
+                    HPCCResultSet res1 = (HPCCResultSet) stmt.executeQuery(stmtsql);
+
+                    if (res1.getRowCount() > 0)
+                        printOutResultSet(res1,0);
+
+                    HPCCResultSet res2 = (HPCCResultSet) stmt.getResultSet();
+                    if (res1.getRowCount() != res2.getRowCount())
+                        throw new RuntimeException("HPCCStatement test: 2 resultsets differ.");
+                }
+                else
+                    throw new RuntimeException("HPCCStatement test failed.");
 
                 if (!runFullTest(info))
                     throw new RuntimeException("Full test failed.");


### PR DESCRIPTION
Implement HPCCStatement (implements JDBC's Statement interface), and change HPCCPreparedStatement to extend newly implemented HPCCStatement.

All common logic and data fields moved from HPCCPreparedStatement to
HPCCStatement. 

Added Traceout statements with local class identifier
for more precise traces (useful during debug of the two classes in question).

Ensure all parser object members are reset in process method

Create new test case.
