### PR TITLE
GH-55 Support aliased duplicate columns

### DIFF
--- a/src/org/hpccsystems/jdbcdriver/ECLEngine.java
+++ b/src/org/hpccsystems/jdbcdriver/ECLEngine.java
@@ -398,13 +398,13 @@ public class ECLEngine
             {
                 selectStructSB.append(col.getEclType())
                               .append(" ")
-                              .append(col.getColumnName())
+                              .append(col.getColumnNameOrAlias())
                               .append(" := ")
                               .append(col.getConstantValue())
                               .append("; ");
 
                 if (i == 0 && expectedretcolumns.size() == 1)
-                    eclEntities.put("SCALAROUTNAME", col.getColumnName());
+                    eclEntities.put("SCALAROUTNAME", col.getColumnNameOrAlias());
             }
             else if (col.getColumnType() == ColumnType.FUNCTION)
             {
@@ -477,7 +477,7 @@ public class ECLEngine
                 eclEntities.put("NONSCALAREXPECTED", "TRUE");
                 selectStructSB.append(col.getEclType())
                 .append(" ")
-                .append(col.getColumnName())
+                .append(col.getColumnNameOrAlias())
                 .append(" := ");
                 if (col.hasContentModifier())
                     selectStructSB.append(col.getContentModifierStr()).append("( ");

--- a/src/org/hpccsystems/jdbcdriver/HPCCColumnMetaData.java
+++ b/src/org/hpccsystems/jdbcdriver/HPCCColumnMetaData.java
@@ -49,11 +49,12 @@ public class HPCCColumnMetaData
     private int                      paramType;
     private String                   javaClassName;
     private String                   constantValue = null;
-    private ColumnType              columnType;
+    private ColumnType               columnType;
     private String                   alias = null;
     private List<HPCCColumnMetaData> funccols = null;
     private boolean                  isDistinct = false;
     private ECLFunction              contentModifier = null;
+    private boolean                  sortAscending = true;
 
     public HPCCColumnMetaData(String columnName, int index, int sqlType, String constant, String eclType)
     {
@@ -290,6 +291,16 @@ public class HPCCColumnMetaData
     public void setContentModifier(ECLFunction contentModifier)
     {
         this.contentModifier = contentModifier;
+    }
+
+    public boolean isSortAscending()
+    {
+        return sortAscending;
+    }
+
+    public void setSortAscending(boolean sortAscending)
+    {
+        this.sortAscending = sortAscending;
     }
 
     @Override

--- a/src/org/hpccsystems/jdbcdriver/HPCCResultSetMetadata.java
+++ b/src/org/hpccsystems/jdbcdriver/HPCCResultSetMetadata.java
@@ -43,12 +43,7 @@ public class HPCCResultSetMetadata implements ResultSetMetaData
         {
             col.setIndex(colIndex++);
 
-            columnListHash.put(col.getColumnName().toUpperCase(), col);
-
-            if (!columnListHash.containsKey(col.getColumnNameOrAlias()))
-            {
-                columnListHash.put(col.getColumnNameOrAlias().toUpperCase(), col);
-            }
+            columnListHash.put(col.getColumnNameOrAlias().toUpperCase(), col);
         }
     }
 

--- a/src/org/hpccsystems/jdbcdriver/tests/HPCCDriverTest.java
+++ b/src/org/hpccsystems/jdbcdriver/tests/HPCCDriverTest.java
@@ -782,6 +782,41 @@ public class HPCCDriverTest
             params.add("'33445'");
             params.add("'90210'");
 
+            executeFreeHandSQL(propsinfo,"select 1 as ONE", params, true, 1, "Select single numeric constant Aliased");
+            executeFreeHandSQL(propsinfo,"select 1 as ONE,2,3 as THREE,4", params, true, 1, "Select four numeric constants Aliased");
+
+            executeFreeHandSQL(propsinfo,
+                    "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) limit 100 ",
+                    params, true, 1, "duplicate column, one aliased");
+
+            executeFreeHandSQL(propsinfo,
+                    "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) order by firstname limit 100 ",
+                    params, true, 1, "duplicate column, one aliased");
+
+            executeFreeHandSQL(propsinfo,
+                    "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) order by NAME limit 100 ",
+                    params, true, 1, "duplicate column, one aliased order by alias name");
+
+            executeFreeHandSQL(propsinfo,
+                    "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) group by NAME limit 100 ",
+                    params, true, 1, "duplicate column, one aliased order by group by alias name");
+
+            executeFreeHandSQL(propsinfo,
+                    "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) group by firstname limit 100 ",
+                    params, true, 1, "duplicate column, one aliased order by group by field name");
+
+            executeFreeHandSQL(propsinfo,
+                    "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) group by firstnamex limit 100 ",
+                    params, false, 0, "duplicate column, one aliased order by group by invalid field name");
+
+            executeFreeHandSQL(propsinfo,
+                    "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) group by xyz.firstname limit 100 ",
+                    params, false, 0, "duplicate column, one aliased order by group by invalid field table name");
+
+            executeFreeHandSQL(propsinfo,
+                    "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname AS LNAME, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) limit 100 ",
+                    params, true, 1, "duplicate column, both aliased");
+
             executeFreeHandSQL(propsinfo,"select 1", params, true, 1, "Select single numeric constant");
             executeFreeHandSQL(propsinfo,"select 1,2,3,4", params, true, 1, "Select four numeric constants");
             executeFreeHandSQL(propsinfo,"select '1a'", params, true, 1, "Select single string constant");


### PR DESCRIPTION
Add support for duplicate columns in select list (as long as n-1 duplicate columns are aliased)
Also support order by and group by aliasing.
Add test cases

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
