### PR TITLE
GH-59 Add support for boolean data type in all logical expressions

### DIFF
--- a/src/org/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
+++ b/src/org/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
@@ -451,6 +451,7 @@ public class HPCCJDBCUtils
     private static HashMap<String, Integer> mapECLTypeNameToSQLType = new HashMap<String, Integer>();
     static
     {
+        mapECLTypeNameToSQLType.put("BOOLEAN", java.sql.Types.BOOLEAN);
         mapECLTypeNameToSQLType.put("STRING", java.sql.Types.VARCHAR);
         mapECLTypeNameToSQLType.put("QSTRING", java.sql.Types.VARCHAR);
         mapECLTypeNameToSQLType.put("FLOAT", java.sql.Types.FLOAT);
@@ -656,5 +657,13 @@ public class HPCCJDBCUtils
             }
         }
         throw new IllegalArgumentException(enumclass.getName() +".'" + strvalue + "' is not valid.");
+    }
+
+    public static final Pattern BOOLEANPATTERN = Pattern.compile(
+            "((?i)true|(?i)false)",Pattern.DOTALL);
+
+    public static boolean isBooleanKeyWord(String str)
+    {
+       return BOOLEANPATTERN.matcher(str).matches();
     }
 }

--- a/src/org/hpccsystems/jdbcdriver/SQLFragment.java
+++ b/src/org/hpccsystems/jdbcdriver/SQLFragment.java
@@ -37,7 +37,8 @@ public class SQLFragment
         LIST,
         CONTENT_MODIFIER,
         FIELD_CONTENT_MODIFIER,
-        AGGREGATE_FUNCTION;
+        AGGREGATE_FUNCTION,
+        BOOLEAN;
     }
 
     private String fnname   =   null;
@@ -114,6 +115,7 @@ public class SQLFragment
                     fragment = HPCCJDBCUtils.replaceSQLwithECLEscapeChar(fragment);
                 case NUMERIC_FRAGMENT:
                 case PARAMETERIZED:
+                case BOOLEAN:
                     setValue(fragment);
                     break;
                 case FIELD:
@@ -171,6 +173,7 @@ public class SQLFragment
                                     case LITERAL_STRING:
                                     case NUMERIC_FRAGMENT:
                                     case PARAMETERIZED:
+                                    case BOOLEAN:
                                         setValue(subfragment);
                                         break;
                                 }
@@ -216,6 +219,10 @@ public class SQLFragment
         else if (HPCCJDBCUtils.isLiteralString(fragStr))
         {
             return FragmentType.LITERAL_STRING;
+        }
+        else if (HPCCJDBCUtils.isBooleanKeyWord(fragStr))
+        {
+            return FragmentType.BOOLEAN;
         }
         else if (HPCCJDBCUtils.isNumeric(fragStr))
         {

--- a/src/org/hpccsystems/jdbcdriver/tests/HPCCDriverTest.java
+++ b/src/org/hpccsystems/jdbcdriver/tests/HPCCDriverTest.java
@@ -787,7 +787,31 @@ public class HPCCDriverTest
 
             executeFreeHandSQL(propsinfo,
                     "select  \"peeps\".\"lastname\" as 'name',  \"progguide::exampledata::people\".\"lastname\" as 'lname', 'lastname'  from \"progguide::exampledata::people\" as \"peeps\" where \"peeps\".\"lastname\" = \"COOLING\" ORDER BY 'firstname' GROUP BY \"peeps\".\"lastname\" limit 100 ",
-                    params, true, 1, "duplicate column, one aliased");
+                    params, true, 1, "fully quoted test");
+
+            executeFreeHandSQL(propsinfo,
+                    "select firstname from badword::search::bool AS badwords where foundword  =  TruE",
+                    params, true, 1, "boolean test true");
+
+            executeFreeHandSQL(propsinfo,
+                    "select firstname from badword::search::bool AS badwords where foundword  =  false",
+                    params, true, 1, "boolean test false");
+
+            executeFreeHandSQL(propsinfo,
+                    "select firstname from badword::search::bool AS badwords where foundword  =  false and foundword  =  tRUE",
+                    params, true, 0, "boolean test true and false");
+
+            executeFreeHandSQL(propsinfo,
+                    "select firstname from badword::search::bool AS badwords where foundword  =  false or foundword  =  tRUE",
+                    params, true, 1, "boolean test true or false");
+
+            executeFreeHandSQL(propsinfo,
+                    "select firstname from badword::search::bool AS badwords where foundword  =  0",
+                    params, false, 0, "bad boolean test, use numeric");
+
+            executeFreeHandSQL(propsinfo,
+                    "select firstname from badword::search::bool AS badwords where foundword  =  'true'",
+                    params, false, 0, "bad boolean test, used literal");
 
             executeFreeHandSQL(propsinfo,
                     "select  peeps.gender as Sex, peeps.firstname AS NAME, peeps.lastname, peeps.lastname AS LNAME2 from progguide::exampledata::people peeps where ( peeps.firstname = 'TIMTOHY' ) limit 100 ",


### PR DESCRIPTION
Driver mimics ECL boolean support. 
Booleans can be assigned case insensitive true|false values.
Add pertinent test cases.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
