### PR TITLE
gh-73 do not use first expression's prev unifier

### DIFF
--- a/src/org/hpccsystems/jdbcdriver/SQLExpression.java
+++ b/src/org/hpccsystems/jdbcdriver/SQLExpression.java
@@ -188,11 +188,11 @@ public class SQLExpression
         return tmpsb.toString();
     }
 
-    public String toStringTranslateSource(HashMap<String, String> map, boolean ignoreMisTraslations)
+    public String toStringTranslateSource(HashMap<String, String> map, boolean ignoreprevunifier, boolean ignoreMisTraslations)
     {
             StringBuffer tmpsb = new StringBuffer();
 
-            if (prevExpUnifier != null)
+            if (!ignoreprevunifier && prevExpUnifier != null )
                 tmpsb.append(prevExpUnifier);
 
             String prefixtranslate = map.get(prefix.getParent());

--- a/src/org/hpccsystems/jdbcdriver/SQLWhereClause.java
+++ b/src/org/hpccsystems/jdbcdriver/SQLWhereClause.java
@@ -121,13 +121,17 @@ public class SQLWhereClause
     {
         String clause = new String("");
         String expstr = null;
-
+        boolean foundFirstExpression = false;
         for (SQLExpression exp : expressions)
         {
-            expstr = exp.toStringTranslateSource(map, ignoreMisTranslations);
+            expstr = exp.toStringTranslateSource(map, !foundFirstExpression, ignoreMisTranslations);
 
             if (expstr != null)
+            {
                 clause += expstr;
+                if (!foundFirstExpression)
+                    foundFirstExpression = true;
+            }
         }
         return clause;
     }


### PR DESCRIPTION
This change has been used for a while in private builds, but was inexplicably not included in rc build.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
