### PR TITLE
GH-76 Consider ecl type precision underscore delimiter

### DIFF
--- a/src/org/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
+++ b/src/org/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
@@ -472,10 +472,11 @@ public class HPCCJDBCUtils
         mapECLTypeNameToSQLType.put("GMONTHDAY", java.sql.Types.DATE);
         mapECLTypeNameToSQLType.put("DURATION", java.sql.Types.VARCHAR);
         mapECLTypeNameToSQLType.put("STRING1", java.sql.Types.CHAR);
+        mapECLTypeNameToSQLType.put("REAL", java.sql.Types.REAL);
     }
 
     private static Pattern TRAILINGNUMERICPATTERN = Pattern.compile(
-            "(.*\\s+?)*([A-Z]+)([0-9]+)*",Pattern.DOTALL);
+            "(.*\\s+?)*([A-Z]+)([0-9]+(_[0-9]+)?)*",Pattern.DOTALL);
 
     public static int mapECLtype2SQLtype(String ecltype)
     {


### PR DESCRIPTION
- Update trailing numeric patern to include possible underscore
  followed by 1 or more numeric chars
- Add missing ECL REAL to SQL REAL type mapping

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
