### PR TITLE
gh-113 JDBC Connection URL values should be url encoded.

### DIFF
--- a/src/main/java/org/hpccsystems/jdbcdriver/HPCCDriver.java
+++ b/src/main/java/org/hpccsystems/jdbcdriver/HPCCDriver.java
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 package org.hpccsystems.jdbcdriver;
 
+import java.net.URLDecoder;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -93,7 +94,7 @@ public class HPCCDriver implements Driver
                             String key = keyvalues.nextToken();
                             String value = keyvalues.nextToken();
                             if (!connprops.containsKey(key))
-                                connprops.put(key, value);
+                                connprops.put(key, URLDecoder.decode(value, "UTF-8"));
                             else
                                 HPCCJDBCUtils.traceoutln(Level.FINEST,  "Connection property: " + key + " found in info properties and URL, ignoring URL value");
                         }

--- a/src/test/java/org/hpccsystems/jdbcdriver/tests/HPCCDriverTest.java
+++ b/src/test/java/org/hpccsystems/jdbcdriver/tests/HPCCDriverTest.java
@@ -1,5 +1,6 @@
 package org.hpccsystems.jdbcdriver.tests;
 
+import java.net.URLEncoder;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
@@ -716,9 +717,11 @@ public class HPCCDriverTest
             for(Object okey : propsinfo.keySet() )
             {
                 String key = (String) okey;
-                infourl += key + "=" + propsinfo.getProperty(key) + ";";
-                System.out.println(key +": " + propsinfo.getProperty(key));
+                String value = URLEncoder.encode(propsinfo.getProperty(key), "UTF-8");
+                infourl += key + "=" + value + ";";
+                System.out.println(key +": " + value);
             }
+            System.out.println(infourl);
             System.out.println("************************************************");
 
             if (!testLazyLoading(propsinfo))
@@ -790,20 +793,21 @@ public class HPCCDriverTest
 
             executeFreeHandSQL(propsinfo,
                     "call myroxie::fetchpeoplebyzipservice()",
-                    params, false, 0, "Call published query not enough in-params");
+                    params, true, 0, "Call published query not enough in-params");
 
             executeFreeHandSQL(propsinfo,
                     "call bogusSPName()",
                     params, false, 0, "Call non-existant published query");
-
-            params.add("'33445'");
-            params.add("'90210'");
 
             params.clear();
             params.add("'zip'");
             executeFreeHandSQL(propsinfo,
                     "select  zip from super::super::tutorial::rp::tutorialperson as persons where count (?) > 0  limit 100",
                     params, true, 1, "Select paremeterized function param");
+
+            params.clear();
+            params.add("'33445'");
+            params.add("'90210'");
 
             executeFreeHandSQL(propsinfo,
                     "select  zip from tutorial::rp::tutorialperson as persons, where zip = '33445'  limit 100",


### PR DESCRIPTION
-Decodes JDBC connection URL values.
 eg. jdbc:hpcc;WsECLWatchAddress=http%3A//192.168.124.128;
     WsECLWatchAddress set to http://192.168.124.128
-Ensure test case encodes URL
Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
